### PR TITLE
doc: Improve README formatting and capitalization IO-100

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Sending the results of running Roslyn Analyzers to Codacy involves the steps bel
 3.  Send the results to Codacy
 4.  Finally, signal that Codacy can use the sent results and start a new analysis
 
+> When the option **“Run analysis through build server”** is enabled, the Codacy analysis will not start until you call the endpoint `/2.0/commit/{commitUuid}/resultsFinal` signalling that Codacy can use the sent results and start a new analysis.
+
 With script:
 
 ```bash
@@ -86,8 +88,6 @@ curl -XPOST -L -H "project-token: $PROJECT_TOKEN" \
     -H "Content-type: application/json" \
     "$CODACY_URL/2.0/commit/$COMMIT/resultsFinal"
 ```
-
-> When the option **“Run analysis through build server”** is enabled, the Codacy analysis will not start until you call the endpoint `/2.0/commit/{commitUuid}/resultsFinal` signalling that Codacy can use the sent results and start a new analysis.
 
 * * *
 


### PR DESCRIPTION
Makes the name and capitalization of the tool consistent in line with the original project's README:

https://github.com/dotnet/roslyn-analyzers#roslyn-analyzers

Also suggests some minor formatting improvements.