### PR TITLE
docs: add tool-description template so we dont forget

### DIFF
--- a/docs/tool-description.md
+++ b/docs/tool-description.md
@@ -1,1 +1,1 @@
-[[ WHAT DO WE PUT HERE ?? ]]
+Roslyn Analyzers analyze your code for style, quality and maintainability, design, and other issues. [Learn more](https://github.com/dotnet/roslyn-analyzers)


### PR DESCRIPTION
Example existing from another tool - https://github.com/codacy/codacy-clang-tidy/blob/master/docs/tool-description.md

@prcr noticed this missing and mentioned at - https://github.com/codacy/docs/pull/1476/files#r1007137009