### PR TITLE
fix: Update tool version to Roslyn Analyzers version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ assembly / assemblyMergeStrategy := {
     oldStrategy(x)
 }
 
-val roslynVersion = "1.14.0"
+val roslynVersion = "3.3.3"
 
 libraryDependencies ++= Seq(
   "com.codacy" %% "codacy-engine-scala-seed" % "6.0.1",

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "codacy-roslyn",
-  "version": "1.14.0",
+  "version": "3.3.3",
   "patterns": [
     {
       "patternId": "UNT0001",


### PR DESCRIPTION
While generating the release notes, I noticed that the version of the new tool is being reported by our API as `1.14.0`. This is in fact the [version of microsoft/Microsoft.Unity.Analyzers](https://github.com/microsoft/Microsoft.Unity.Analyzers/releases/tag/1.14.0).

However, according to @vascorsd on https://github.com/codacy/docs/pull/1476#discussion_r1009325899, the tool can actually run different Roslyn Analyzers and we may support additional "plugins" in the future. So, I believe that we should report the [latest version of dotnet/roslyn-analyzers](https://github.com/dotnet/roslyn-analyzers/releases/tag/v3.3.3) instead, which is `3.3.3`.

I also noticed that the file https://github.com/codacy/codacy-roslyn/blob/master/.version already mentions the version `3.3.3`.