### PR TITLE
Change the public description of the tool to focus on Unity

### DIFF
--- a/docs/tool-description.md
+++ b/docs/tool-description.md
@@ -1,1 +1,1 @@
-Unity-specific diagnostics for C# Unity projects. [Learn more](https://github.com/microsoft/microsoft.unity.analyzers)
+Unity-specific diagnostics for CSharp Unity projects. [Learn more](https://github.com/microsoft/microsoft.unity.analyzers)


### PR DESCRIPTION
Also changes the link of the learn more to point directly to the unity upstream roslyn support instead of the roslyn itself.