### PR TITLE
Bump Unity Roslyn Analyzers to 1.26.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ assembly / assemblyMergeStrategy := {
     oldStrategy(x)
 }
 
-val roslynVersion = "1.23.0"
+val roslynVersion = "1.26.0"
 
 libraryDependencies ++= Seq(
   "com.codacy" %% "codacy-engine-scala-seed" % "6.1.5",

--- a/doc-generator/src/main/scala/com/codacy/roslyn/DocGenerator.scala
+++ b/doc-generator/src/main/scala/com/codacy/roslyn/DocGenerator.scala
@@ -87,6 +87,7 @@ object DocGenerator {
       case "Correctness" => "ErrorProne"
       case "Performance" => "Performance"
       case "Type Safety" => "ErrorProne"
+      case "Readability" => "CodeStyle"
     }
   }
 

--- a/docs/description/UNT0039.md
+++ b/docs/description/UNT0039.md
@@ -1,0 +1,40 @@
+# UNT0039 Use `RequireComponent` attribute when self-invoking `GetComponent`
+
+The `RequireComponent` attribute automatically adds required components as dependencies.
+
+When you add a script which uses `RequireComponent` to a `GameObject`, the required component is automatically added to the `GameObject`. This is useful to avoid setup errors. For example a script might require that a `Rigidbody` is always added to the same `GameObject`. When you use `RequireComponent`, this is done automatically, so you are unlikely to get the setup wrong.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        var rb = GetComponent<Rigidbody>();
+        ...
+    }
+}
+```
+
+## Solution
+
+Use `RequiredComponent` attribute:
+
+```csharp
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        var rb = GetComponent<Rigidbody>();
+        ...
+    }
+}
+```
+
+A code fix is offered for this diagnostic to automatically apply this change.

--- a/docs/description/UNT0040.md
+++ b/docs/description/UNT0040.md
@@ -1,0 +1,39 @@
+# UNT0040 GameObject.isStatic is editor-only
+
+`GameObject.isStatic` is only usable in the Editor. In builds, it always returns `false`. Use editor-only code or editor callbacks like `OnValidate`/`Reset` when accessing `isStatic`.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        if (gameObject.isStatic)
+        {
+            // This will never execute in builds
+        }
+    }
+}
+```
+
+## Solution
+
+Use it within editor-only Unity messages like `OnValidate` or `Reset`:
+
+```csharp
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void OnValidate()
+    {
+        if (gameObject.isStatic)
+        {
+            // This is acceptable because OnValidate is editor-only
+        }
+    }
+}
+```

--- a/docs/description/UNT0041.md
+++ b/docs/description/UNT0041.md
@@ -1,0 +1,48 @@
+# UNT0041 Use Animator.StringToHash for repeated Animator method calls
+
+`Animator` methods have overloads that accept either a string or an int (hash) parameter. Using the string-based overload repeatedly causes Unity to compute the hash every time, which impacts performance.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    private Animator _animator;
+
+    void Update()
+    {
+        // UNT0041: Use Animator.StringToHash for repeated Animator method calls
+        _animator.Play("Attack");
+        _animator.SetBool("IsRunning", true);
+        _animator.SetFloat("Speed", 1.5f);
+    }
+}
+```
+
+## Solution
+
+Pre-compute the hash using `Animator.StringToHash` and store it in a static readonly field:
+
+```csharp
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    private static readonly int AttackHash = Animator.StringToHash("Attack");
+    private static readonly int IsRunningHash = Animator.StringToHash("IsRunning");
+    private static readonly int SpeedHash = Animator.StringToHash("Speed");
+
+    private Animator _animator;
+
+    void Update()
+    {
+        _animator.Play(AttackHash);
+        _animator.SetBool(IsRunningHash, true);
+        _animator.SetFloat(SpeedHash, 1.5f);
+    }
+}
+```
+
+A code fix is offered for this diagnostic to automatically extract the string literal to a cached hash field.

--- a/docs/description/UNT0042.md
+++ b/docs/description/UNT0042.md
@@ -1,0 +1,63 @@
+# UNT0042 Mesh array property accessed in loop
+
+Accessing array properties like `vertices`, `normals`, `tangents`, `uv`, `colors`, etc. on `Mesh` inside a loop causes a new array allocation on each access. This can significantly impact performance, especially in frequently called methods like `Update()`.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    void Update()
+    {
+        Mesh mesh = GetComponent<MeshFilter>().mesh;
+
+        // Bad: mesh.vertices allocates a new array on every iteration
+        for (int i = 0; i < mesh.vertices.Length; i++)
+        {
+            // ...
+        }
+
+        // Bad: mesh.vertices and mesh.normals allocate new arrays on every iteration
+        for (int i = 0; i < mesh.vertexCount; i++)
+        {
+            mesh.vertices[i] += mesh.normals[i] * Time.deltaTime;
+        }
+    }
+}
+```
+
+## Solution
+
+Cache the array property in a local variable before the loop:
+
+```csharp
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    void Update()
+    {
+        Mesh mesh = GetComponent<MeshFilter>().mesh;
+
+        // Good: cache the array before the loop
+        Vector3[] vertices = mesh.vertices;
+        for (int i = 0; i < vertices.Length; i++)
+        {
+            // ...
+        }
+
+        // Good: cache arrays before the loop, assign back after modifications
+        Vector3[] verts = mesh.vertices;
+        Vector3[] normals = mesh.normals;
+        for (int i = 0; i < verts.Length; i++)
+        {
+            verts[i] += normals[i] * Time.deltaTime;
+        }
+        mesh.vertices = verts;
+    }
+}
+```
+
+A code fix is offered for this diagnostic to automatically cache the array property in a local variable.

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -188,5 +188,25 @@
     "patternId": "UNT0038",
     "title": "Cache `WaitForSeconds` invocations",
     "description": "Cache `WaitForSeconds` invocations"
+  },
+  {
+    "patternId": "UNT0039",
+    "title": "Use `RequireComponent` attribute when self-invoking `GetComponent`",
+    "description": "Use `RequireComponent` attribute when self-invoking `GetComponent`"
+  },
+  {
+    "patternId": "UNT0040",
+    "title": "`GameObject.isStatic` is editor-only",
+    "description": "`GameObject.isStatic` is editor-only"
+  },
+  {
+    "patternId": "UNT0041",
+    "title": "Use `Animator.StringToHash` for repeated `Animator` method calls",
+    "description": "Use `Animator.StringToHash` for repeated `Animator` method calls"
+  },
+  {
+    "patternId": "UNT0042",
+    "title": "`Mesh` array property accessed in loop",
+    "description": "`Mesh` array property accessed in loop"
   }
 ]

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn",
-  "version": "1.23.0",
+  "version": "1.26.0",
   "patterns": [
     {
       "patternId": "UNT0001",
@@ -170,12 +170,12 @@
     {
       "patternId": "UNT0034",
       "level": "Warning",
-      "category": "Performance"
+      "category": "CodeStyle"
     },
     {
       "patternId": "UNT0035",
       "level": "Warning",
-      "category": "Performance"
+      "category": "CodeStyle"
     },
     {
       "patternId": "UNT0036",
@@ -189,6 +189,26 @@
     },
     {
       "patternId": "UNT0038",
+      "level": "Warning",
+      "category": "Performance"
+    },
+    {
+      "patternId": "UNT0039",
+      "level": "Warning",
+      "category": "ErrorProne"
+    },
+    {
+      "patternId": "UNT0040",
+      "level": "Warning",
+      "category": "ErrorProne"
+    },
+    {
+      "patternId": "UNT0041",
+      "level": "Warning",
+      "category": "Performance"
+    },
+    {
+      "patternId": "UNT0042",
       "level": "Warning",
       "category": "Performance"
     }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.12.14


### PR DESCRIPTION
## Summary
- Bump wrapped Unity Roslyn Analyzers (`roslynVersion` in `build.sbt`) from `1.23.0` to `1.26.0` (latest upstream release, confirmed via `microsoft/Microsoft.Unity.Analyzers` GitHub releases).
- Regenerated `docs/patterns.json` and `docs/description/*` via `sbt "doc-generator/run"`.
  - Upstream added a new rule category, **Readability**, which the generator didn't handle (`DocGenerator.toCodacyCategory` threw a `MatchError`). Added a mapping `"Readability" -> "CodeStyle"` (Codacy's closest equivalent category, per `com.codacy.plugins.api.results.Pattern.Category`).
  - As a result, existing rules `UNT0034`/`UNT0035` moved from `Performance` to `CodeStyle` (their upstream category changed to Readability), and four new rules were added: `UNT0039`, `UNT0040`, `UNT0041`, `UNT0042`.
- Bumped `sbt.version` in `project/build.properties` from `1.10.1` to `1.12.14` (latest sbt 1.x release). Did **not** jump to sbt 2.0 — that's a major version bump with uncertain compatibility with the pinned `sbt-native-image`/`sbt-assembly`/`codacy-sbt-plugin` versions, so left for a separate, deliberate change.
- No other dependency bumps included: I could not reliably verify newer versions of `codacy-engine-scala-seed`, `ujson`, `codacy-analysis-cli-model`, `scalatest`, `scala-xml`, `better-files`, `codacy-sbt-plugin`, `sbt-native-image`, `sbt-assembly`, or the CircleCI orbs in this environment (direct Maven Central metadata fetches were blocked/403'd, and the search API's summarized results were internally inconsistent — e.g. reporting versions *older* than what's already pinned). Rather than guess, I left those unchanged.

## Test plan
- [x] `sbt "doc-generator/run"` — regenerated docs successfully after the category-mapping fix
- [x] `sbt scalafmtAll` — no formatting diffs beyond the intentional change
- [x] `sbt compile` — succeeds
- [x] `sbt test` — `ConverterSpecs` and `RoslynReportParserSpecs` pass (2/2)
- [x] `sbt assembly` — succeeds
- [x] `docker build -t codacy-roslyn .` — succeeds
- [ ] `sbt nativeImage` — fails locally with `DARWIN does not support building static executable images` (macOS can't build `--static` GraalVM images). This is an environment limitation, not caused by this change; CI runs on Linux where this works. Will confirm via CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)